### PR TITLE
Implement automerge github action

### DIFF
--- a/.github/workflows/automerge_pull_requests.yml
+++ b/.github/workflows/automerge_pull_requests.yml
@@ -1,0 +1,29 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  status: {}
+
+jobs:
+  automerge:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Merge pull requests
+      uses: pascalgn/automerge-action@v0.3.2
+      env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          LABELS: "approved,Hacktoberfest,!invalid"
+          AUTOMERGE: "ready-to-merge"


### PR DESCRIPTION
Implement automerge action that auto merges pull requests having `approved`, `Hacktoberfest` and `ready-to-merge` labels, and not having an `invalid` label.